### PR TITLE
Add configurable gallery page with modal image viewer

### DIFF
--- a/_data/gallery.yml
+++ b/_data/gallery.yml
@@ -1,0 +1,6 @@
+- image: "/images/gallery/birds_1.jpg"
+  description: "Bird sitting on a branch"
+- image: "/images/gallery/birds_2.jpg"
+  description: "Flying bird"
+- image: "/images/gallery/birds_3.jpg"
+  # description is optional

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,9 +12,12 @@ main:
     
   - title: "Teaching"
     url: /teaching/
-    
+
   - title: "Tutorials"
     url: /tutorials/
+
+  - title: "Gallery"
+    url: /gallery/
 
   # - title: "Portfolio"
     # url: /portfolio/

--- a/_pages/gallery.html
+++ b/_pages/gallery.html
@@ -1,0 +1,47 @@
+---
+layout: single
+title: "Gallery"
+permalink: /gallery/
+author_profile: true
+columns: 3
+---
+
+<div class="gallery" style="--gallery-columns: {{ page.columns | default: 3 }}">
+  {% for item in site.data.gallery %}
+  <figure class="gallery-item">
+    <img src="{{ item.image }}" alt="{{ item.description | default: 'Gallery image' }}" data-desc="{{ item.description | escape }}">
+    {% if item.description %}
+    <figcaption>{{ item.description }}</figcaption>
+    {% endif %}
+  </figure>
+  {% endfor %}
+</div>
+
+<div id="gallery-modal" class="gallery-modal">
+  <span class="gallery-close">&times;</span>
+  <img src="" alt="">
+  <p class="desc"></p>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+  const modal = document.getElementById('gallery-modal');
+  const modalImg = modal.querySelector('img');
+  const modalDesc = modal.querySelector('.desc');
+  const closeBtn = modal.querySelector('.gallery-close');
+
+  document.querySelectorAll('.gallery-item img').forEach(img => {
+    img.addEventListener('click', () => {
+      modalImg.src = img.src;
+      modalDesc.textContent = img.dataset.desc || '';
+      modal.classList.add('open');
+    });
+  });
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal || e.target === closeBtn) {
+      modal.classList.remove('open');
+    }
+  });
+});
+</script>

--- a/_sass/_gallery.scss
+++ b/_sass/_gallery.scss
@@ -1,0 +1,65 @@
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(var(--gallery-columns, 3), 1fr);
+  gap: 1rem;
+}
+
+.gallery-item {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-item figcaption {
+  text-align: center;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+
+.gallery-modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.gallery-modal.open {
+  display: flex;
+}
+
+.gallery-modal img {
+  max-width: 90%;
+  max-height: 80%;
+}
+
+.gallery-modal .desc {
+  margin-top: 1rem;
+  color: #fff;
+  text-align: center;
+  max-width: 90%;
+}
+
+.gallery-close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  color: #fff;
+  font-size: 2rem;
+  cursor: pointer;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -37,3 +37,4 @@
 @import "vendor/font-awesome/font-awesome";
 @import "vendor/magnific-popup/magnific-popup";
 @import "print";
+@import "gallery";


### PR DESCRIPTION
## Summary
- add navigation link and data-driven gallery page
- style gallery grid and modal overlay
- expose configurable column layout

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68a9c11bfe3883268e760a63eadaf567